### PR TITLE
BAU: Improvements to SAM stack deployment and deletion actions

### DIFF
--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -69,7 +69,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/aws/ecr/check-image-exists/action.yml
+++ b/aws/ecr/check-image-exists/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/aws/ecr/delete-docker-images/action.yml
+++ b/aws/ecr/delete-docker-images/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/aws/ecs/deregister-stale-task-definitions/action.yml
+++ b/aws/ecs/deregister-stale-task-definitions/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/aws/ecs/register-task-definition/action.yml
+++ b/aws/ecs/register-task-definition/action.yml
@@ -44,7 +44,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/aws/ssm/get-parameters/action.yml
+++ b/aws/ssm/get-parameters/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/sam/check-stacks-exist/action.yml
+++ b/sam/check-stacks-exist/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Delete a stack only if it is in one of the failed states"
     required: false
     default: "false"
+  verbose:
+    description: "Print all output messages"
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -32,3 +36,4 @@ runs:
       env:
         STACK_NAMES: ${{ inputs.stack-names }}
         ONLY_FAILED: ${{ inputs.only-if-failed == 'true' }}
+        VERBOSE: ${{ inputs.verbose == 'true' }}

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -48,6 +48,9 @@ inputs:
     description: "The path at which the artifact contents should be placed"
     required: false
 outputs:
+  aws-region:
+    description: "The region in which the stack was deployed"
+    value: ${{ inputs.aws-region }}
   stack-name:
     description: "The deployed stack name"
     value: ${{ steps.set-stack-name.outputs.stack-name }}

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -44,6 +44,9 @@ inputs:
   artifact-name:
     description: "The name of the distribution artifact to download"
     required: false
+  artifact-path:
+    description: "The path at which the artifact contents should be placed"
+    required: false
 outputs:
   stack-name:
     description: "The deployed stack name"
@@ -66,6 +69,7 @@ runs:
       uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}
 
     - name: Validate SAM template
       if: ${{ inputs.template != null }}

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -50,7 +50,7 @@ inputs:
 outputs:
   stack-name:
     description: "The deployed stack name"
-    value: ${{ env.STACK_NAME }}
+    value: ${{ steps.set-stack-name.outputs.stack-name }}
   stack-url:
     description: "The URL of the deployed stack in the AWS console"
     value: ${{ steps.set-stack-name.outputs.stack-url }}
@@ -134,6 +134,7 @@ runs:
       run: |
         url="https://${AWS_REGION}.console.aws.amazon.com/cloudformation/home#/stacks/stackinfo?stackId=${STACK_NAME}"
         echo "stack-url=$url" >> "$GITHUB_OUTPUT"
+        echo "stack-name=$STACK_NAME" >> "$GITHUB_OUTPUT"
         echo "STACK_NAME=$STACK_NAME" >> "$GITHUB_ENV"
 
     - name: Delete failed stack

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "Stack name prefix to use when deriving the name from the branch name"
     required: false
   s3-prefix:
-    description: "A prefix to use when uploading deployment artifacts"
+    description: "A prefix to use when uploading deployment artifacts; by default the same as the stack prefix"
     required: false
   sam-deployment-bucket:
     description: "S3 bucket used to store the deployment artifacts"
@@ -149,8 +149,8 @@ runs:
       shell: bash
       env:
         TEMPLATE: ${{ inputs.template }}
-        S3_PREFIX: ${{ inputs.s3-prefix }}
         S3_BUCKET: ${{ inputs.sam-deployment-bucket }}
+        S3_PREFIX: ${{ inputs.s3-prefix || inputs.stack-name-prefix }}
         DISABLE_ROLLBACK: ${{ inputs.disable-rollback == 'true' || '' }}
         PARAMETERS: ${{ steps.parse-parameters.outputs.parameters }}
         TAGS: ${{ steps.parse-tags.outputs.tags }}

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/secure-pipelines/await-pipeline-execution/action.yml
+++ b/secure-pipelines/await-pipeline-execution/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/secure-pipelines/deploy-application/action.yml
+++ b/secure-pipelines/deploy-application/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/secure-pipelines/deploy-fargate/action.yml
+++ b/secure-pipelines/deploy-fargate/action.yml
@@ -69,7 +69,7 @@ runs:
         path: ${{ inputs.artifact-path }}
 
     - name: Assume AWS Role
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-session-name: ${{ inputs.aws-session-name }}

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -43,7 +43,7 @@ runs:
   steps:
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
- Add a parameter to the deploy SAM stack action to specify the artifact destination
- Use the stack name prefix as the default S3 prefix when deploying a stack
- Ensure the stack name is always passed as output when deploying a stack
- Output the AWS region when deploying a stack
- Use the latest version of the aws-actions/configure-aws-credentials action
- Add a verbose flag to the delete stacks sript and action