### PR TITLE
OJ-1960: Set SonarCloud base dir by default to avoid permissions issue

### DIFF
--- a/code-quality/sonarcloud/action.yml
+++ b/code-quality/sonarcloud/action.yml
@@ -7,6 +7,7 @@ inputs:
   projectBaseDir:
     description: "Set the sonar.projectBaseDir analysis property"
     required: false
+    default: ${{ github.workspace }}
   coverage-artifact:
     description: "Name of the artifact containing the coverage report (lcov.info file)"
     required: false


### PR DESCRIPTION
The SonarCloud cleanup script needs write permissions but the default base dir is the root of the file system where it cannot run the "chown" command. Set the base dir to the location where the repository is checked out by default to prevent the job from failing due to lack of permissions.