### PR TITLE
OJ-2209: Cache SAM dependencies by default

### DIFF
--- a/code-quality/sonarcloud/action.yml
+++ b/code-quality/sonarcloud/action.yml
@@ -21,10 +21,15 @@ inputs:
   sonar-token:
     description: "The token to authenticate access to SonarCloud"
     required: true
+  pull-repository:
+    description: "Pull the repository before running the scan"
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
     - name: Pull repository
+      if: ${{ inputs.pull-repository == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -26,8 +26,9 @@ inputs:
     required: false
     default: "false"
   cache-key:
-    description: "Key to use for caching SAM dependencies. Caching is disabled if the key is not provided."
+    description: "Customise the key to use for caching SAM dependencies"
     required: false
+    default: build
   disable-parallel:
     description: "Set to true to build the resources sequentially"
     required: false
@@ -56,14 +57,11 @@ runs:
       run: $VALIDATE
 
     - name: Cache SAM dependencies
-      if: ${{ inputs.cache-key != null }}
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-sam-${{ inputs.cache-key }}-${{ hashFiles('**/package-lock.json', inputs.template) }}
+        key: ${{ runner.os }}-sam-${{ inputs.cache-key }}-${{ github.head_ref || github.ref_name }}
         restore-keys: ${{ runner.os }}-sam-${{ inputs.cache-key }}-
-        path: |
-          .aws-sam
-          !.aws-sam/build
+        path: .aws-sam
 
     - name: Build SAM Application
       shell: bash

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: "Pull the repository before uploading the package"
     required: false
     default: "true"
+  cache-key:
+    description: "Customise the key to use for caching SAM dependencies"
+    required: false
+    default: build
   artifact-name:
     description: "The name of the distribution artifact to download"
     required: false
@@ -66,6 +70,13 @@ runs:
     - name: Pull repository
       if: ${{ inputs.pull-repository == 'true' }}
       uses: actions/checkout@v3
+
+    - name: Cache SAM dependencies
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-sam-${{ inputs.cache-key }}-${{ github.head_ref || github.ref_name }}
+        restore-keys: ${{ runner.os }}-sam-${{ inputs.cache-key }}-
+        path: .aws-sam
 
     - name: Get distribution artifact
       if: ${{ inputs.artifact-name != null }}


### PR DESCRIPTION
OJ-2209: Cache SAM dependencies by default to improve performance for Java projects

- Make the cache branch-specific as it doesn't need to be reset when the package files change
- Cache all SAM artifacts when building and deploying SAM stacks

OJ-2209: Optionally pull repository when running a SonarCloud scan