### PR TITLE
BAU: Add actions to set up a Node environment

### DIFF
--- a/code-quality/run-pre-commit/action.yml
+++ b/code-quality/run-pre-commit/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Install dev packages from package.json - this is needed for hooks which have dependencies"
     required: false
     default: "false"
+  package-manager:
+    description: "The package manager to use to install dependencies - npm or yarn"
+    required: false
+    default: npm
   pull-repository:
     description: "Pull the repository before running pre-commit"
     required: false
@@ -51,12 +55,15 @@ runs:
       if: ${{ inputs.install-dependencies == 'true' }}
       uses: actions/setup-node@v4
       with:
-        cache: npm
+        cache: ${{ inputs.package-manager }}
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
       shell: bash
-      run: npm ci --include dev
+      env:
+        PKG_MGR: ${{ inputs.package-manager }}
+      run: |
+        [[ $PKG_MGR == npm ]] && npm ci || yarn install --frozen-lockfile
 
     - name: Install pre-commit
       run: echo "::group::pip output" && pip install pre-commit && echo "::endgroup::"

--- a/env/install-dependencies/action.yml
+++ b/env/install-dependencies/action.yml
@@ -1,0 +1,28 @@
+name: "Install Node.js packages"
+description: "Checkout code, set up Node and install packages"
+inputs:
+  node-version:
+    description: "Node version to set up. The system version is used if not specified."
+    required: false
+  package-manager:
+    description: "The package manager to use - npm or yarn"
+    required: false
+    default: npm
+runs:
+  using: composite
+  steps:
+    - name: Pull repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.package-manager }}
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        PKG_MGR: ${{ inputs.package-manager }}
+      run: |
+        [[ $PKG_MGR == npm ]] && npm ci || yarn install --frozen-lockfile

--- a/env/run-script/action.yml
+++ b/env/run-script/action.yml
@@ -1,0 +1,37 @@
+name: "Run a script in a Node.js environment"
+description: "Checkout code, set up Node, install packages and run the specified script"
+inputs:
+  script:
+    description: "The script to run"
+    required: true
+  node-version:
+    description: "Node version to set up. The system version is used if not specified."
+    required: false
+  package-manager:
+    description: "The package manager to use - npm or yarn"
+    required: false
+    default: npm
+runs:
+  using: composite
+  steps:
+    - name: Pull repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.package-manager }}
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        PKG_MGR: ${{ inputs.package-manager }}
+      run: |
+        [[ $PKG_MGR == npm ]] && npm ci || yarn install --frozen-lockfile
+
+    - name: Run script
+      shell: bash
+      env:
+        COMMAND: ${{ inputs.script }}
+      run: $COMMAND


### PR DESCRIPTION
- Add an action to set up Node environment
  The action checks out the code, sets up Node and installs packages. This can be used as a step in a larger workflow to reduce duplication and boilerplate.

- Add an action to run a script in a Node environment
  This is useful if a specified script needs to be run in a Node environment with installed packages.

- Allow to install packages using yarn for pre-commit
  Add a parameter to specify the package manager to use.