### PR TITLE
BAU: Reset SAM cache when the dependencies change

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Checkov
         uses: ./code-quality/run-checkov
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run shell checks
         uses: ./code-quality/check-shell-scripts

--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 
       - name: Downcase branch name

--- a/.github/workflows/test-check-stacks-exist.yml
+++ b/.github/workflows/test-check-stacks-exist.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"

--- a/.github/workflows/test-delete-stacks.yml
+++ b/.github/workflows/test-delete-stacks.yml
@@ -12,7 +12,7 @@ jobs:
       DELETED_STACKS_FILE: deleted_stacks
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install jp
         shell: bash

--- a/.github/workflows/test-deploy-to-paas.yml
+++ b/.github/workflows/test-deploy-to-paas.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up stub CF CLI
         run: echo "./.github/stubs/cf" >> "$GITHUB_PATH"

--- a/.github/workflows/test-get-ssm-parameters.yml
+++ b/.github/workflows/test-get-ssm-parameters.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"

--- a/.github/workflows/test-get-stale-stacks.yml
+++ b/.github/workflows/test-get-stale-stacks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"

--- a/.github/workflows/test-parse-parameters.yml
+++ b/.github/workflows/test-parse-parameters.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 
       - name: Parse single-line parameters

--- a/.github/workflows/test-print-file-to-step-summary.yml
+++ b/.github/workflows/test-print-file-to-step-summary.yml
@@ -11,7 +11,7 @@ jobs:
       REPORT_FILE_NAME: test-result.txt
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Write stub report
         env:

--- a/.github/workflows/test-print-list-to-step-summary.yml
+++ b/.github/workflows/test-print-list-to-step-summary.yml
@@ -11,7 +11,7 @@ jobs:
       STUB_REPORT_FILE_NAME: test-result.txt
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Write stub report
         env:

--- a/.github/workflows/test-upload-assets.yml
+++ b/.github/workflows/test-upload-assets.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"

--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -131,7 +131,7 @@ runs:
 
     - name: Get distribution artifact
       if: ${{ steps.check-image-exists.outputs.image-digest == null && inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}

--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -127,7 +127,7 @@ runs:
 
     - name: Pull repository
       if: ${{ steps.check-image-exists.outputs.image-digest == null && inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get distribution artifact
       if: ${{ steps.check-image-exists.outputs.image-digest == null && inputs.artifact-name != null }}

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -37,13 +37,13 @@ runs:
 
     - name: Set up Node
       if: ${{ inputs.run-prettier == 'true' || inputs.run-eslint == 'true' }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: npm
 
     - name: Set up Python
       if: ${{ inputs.run-cfn-lint == 'true' }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache-dependency-path: ./.github/workflows

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -31,7 +31,7 @@ runs:
         echo "MERGING=${merging:-false}" >> "$GITHUB_ENV"
 
     - name: Pull repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 

--- a/code-quality/check-shell-scripts/action.yml
+++ b/code-quality/check-shell-scripts/action.yml
@@ -31,7 +31,7 @@ runs:
         echo "MERGING=$merging" >> "$GITHUB_ENV"
 
     - name: Pull repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 

--- a/code-quality/codeql/action.yml
+++ b/code-quality/codeql/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Pull repository
       if: ${{ inputs.autobuild == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Parse languages
       id: get-languages

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "merging=$merging" >> "$GITHUB_OUTPUT"
 
     - name: Pull repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -30,7 +30,7 @@ runs:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11.6'
         cache-dependency-path: ./.github/workflows

--- a/code-quality/run-pre-commit/action.yml
+++ b/code-quality/run-pre-commit/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Pull repository
       if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 

--- a/code-quality/run-pre-commit/action.yml
+++ b/code-quality/run-pre-commit/action.yml
@@ -70,7 +70,7 @@ runs:
       shell: bash
 
     - name: Cache pre-commit dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ runner.os }}-pre-commit-${{ github.head_ref || github.ref_name }}
         restore-keys: ${{ runner.os }}-pre-commit-

--- a/code-quality/run-pre-commit/action.yml
+++ b/code-quality/run-pre-commit/action.yml
@@ -45,7 +45,7 @@ runs:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         cache-dependency-path: ./.github/workflows

--- a/code-quality/run-security-audit/action.yml
+++ b/code-quality/run-security-audit/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Pull repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 

--- a/code-quality/run-security-audit/action.yml
+++ b/code-quality/run-security-audit/action.yml
@@ -18,7 +18,7 @@ runs:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: npm
 

--- a/code-quality/sonarcloud/action.yml
+++ b/code-quality/sonarcloud/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Get coverage results
       if: ${{ inputs.coverage-artifact != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.coverage-artifact }}
         path: ${{ inputs.coverage-location }}

--- a/env/install-dependencies/action.yml
+++ b/env/install-dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}

--- a/env/install-dependencies/action.yml
+++ b/env/install-dependencies/action.yml
@@ -25,4 +25,4 @@ runs:
       env:
         PKG_MGR: ${{ inputs.package-manager }}
       run: |
-        [[ $PKG_MGR == npm ]] && npm ci || yarn install --frozen-lockfile
+        [[ $PKG_MGR == npm ]] && npm ci --include-workspace-root || yarn install --frozen-lockfile

--- a/env/install-dependencies/action.yml
+++ b/env/install-dependencies/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: "The package manager to use - npm or yarn"
     required: false
     default: npm
+  working-directory:
+    description: "The working directory to use"
+    required: false
 runs:
   using: composite
   steps:
@@ -21,6 +24,7 @@ runs:
         cache: ${{ inputs.package-manager }}
 
     - name: Install dependencies
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
         PKG_MGR: ${{ inputs.package-manager }}

--- a/env/run-script/action.yml
+++ b/env/run-script/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         PKG_MGR: ${{ inputs.package-manager }}
       run: |
-        [[ $PKG_MGR == npm ]] && npm ci || yarn install --frozen-lockfile
+        [[ $PKG_MGR == npm ]] && npm ci --include-workspace-root || yarn install --frozen-lockfile
 
     - name: Run script
       shell: bash

--- a/env/run-script/action.yml
+++ b/env/run-script/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: "The package manager to use - npm or yarn"
     required: false
     default: npm
+  working-directory:
+    description: "The working directory to use"
+    required: false
 runs:
   using: composite
   steps:
@@ -24,6 +27,7 @@ runs:
         cache: ${{ inputs.package-manager }}
 
     - name: Install dependencies
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
         PKG_MGR: ${{ inputs.package-manager }}
@@ -31,6 +35,7 @@ runs:
         [[ $PKG_MGR == npm ]] && npm ci --include-workspace-root || yarn install --frozen-lockfile
 
     - name: Run script
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
         COMMAND: ${{ inputs.script }}

--- a/env/run-script/action.yml
+++ b/env/run-script/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -78,7 +78,7 @@ runs:
         echo "restore-keys=$restore_key-" >> "$GITHUB_OUTPUT"
 
     - name: Cache SAM dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ steps.get-cache-key.outputs.cache-key }}
         restore-keys: ${{ steps.get-cache-key.outputs.restore-keys }}

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -100,7 +100,7 @@ runs:
 
     - name: Archive SAM distribution artifact
       if: ${{ inputs.upload-artifact && inputs.artifact-name != null }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         retention-days: 3

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Pull repository
       if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Validate SAM template
       shell: bash

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -11,6 +11,9 @@ inputs:
   base-dir:
     description: "Resolve relative paths to lambda functions' source code with respect to this folder"
     required: false
+  source-dir:
+    description: "Source code directory to use as a cache key when building the SAM application"
+    required: false
   artifact-name:
     description: "Name of the artifact to upload"
     required: false
@@ -25,8 +28,8 @@ inputs:
     description: "Use SAM beta features when building an application"
     required: false
     default: "false"
-  cache-key:
-    description: "Customise the key to use for caching SAM dependencies"
+  cache-name:
+    description: "Customise the key used for caching SAM dependencies"
     required: false
     default: build
   disable-parallel:
@@ -41,6 +44,12 @@ outputs:
   artifact-name:
     description: "Pass through the artifact name"
     value: ${{ inputs.artifact-name }}
+  cache-key:
+    description: "The cache key used when building the SAM application"
+    value: ${{ steps.get-cache-key.outputs.cache-key }}
+  cache-restore-keys:
+    description: "The cache restore keys used when building the SAM application"
+    value: ${{ steps.get-cache-key.outputs.restore-keys }}
 runs:
   using: composite
   steps:
@@ -56,11 +65,23 @@ runs:
         VALIDATE: ${{ github.action_path }}/../../scripts/aws/sam/validate-template.sh
       run: $VALIDATE
 
+    - name: Get cache key
+      id: get-cache-key
+      shell: bash
+      env:
+        OS: ${{ runner.os }}
+        CACHE_NAME: ${{ inputs.cache-name }}
+        HASH: ${{ hashFiles(inputs.template || '**/template.y*ml', inputs.source-dir) }}
+      run: |
+        restore_key=$OS-sam-$CACHE_NAME
+        echo "cache-key=$restore_key-$HASH" >> "$GITHUB_OUTPUT"
+        echo "restore-keys=$restore_key-" >> "$GITHUB_OUTPUT"
+
     - name: Cache SAM dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-sam-${{ inputs.cache-key }}-${{ github.head_ref || github.ref_name }}
-        restore-keys: ${{ runner.os }}-sam-${{ inputs.cache-key }}-
+        key: ${{ steps.get-cache-key.outputs.cache-key }}
+        restore-keys: ${{ steps.get-cache-key.outputs.restore-keys }}
         path: .aws-sam
 
     - name: Build SAM Application
@@ -69,14 +90,12 @@ runs:
         TEMPLATE_FILE: ${{ inputs.template }}
         BETA_FEATURES: ${{ inputs.enable-beta-features == 'true' }}
         PARALLEL: ${{ inputs.disable-parallel == 'false' }}
-        CACHE: ${{ inputs.cache-key != 'null' }}
         BASE_DIR: ${{ inputs.base-dir }}
       run: |
-        sam build \
+        sam build --cached \
           ${TEMPLATE_FILE:+--template-file "$TEMPLATE_FILE"} \
           ${BASE_DIR:+--base-dir "$BASE_DIR"} \
           "$($PARALLEL && echo "--parallel")" \
-          "$($CACHE && echo "--cached" || echo "--no-cached")" \
           "$($BETA_FEATURES && echo "--beta-features")"
 
     - name: Archive SAM distribution artifact

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -45,10 +45,16 @@ inputs:
     description: "Pull the repository before uploading the package"
     required: false
     default: "true"
-  cache-key:
-    description: "Customise the key to use for caching SAM dependencies"
+  cache-name:
+    description: "Customise the key to use for caching SAM dependencies when no cache key is provided"
     required: false
     default: build
+  cache-key:
+    description: "The cache key used when building the SAM application"
+    required: false
+  cache-restore-keys:
+    description: "The cache restored keys used when building the SAM application"
+    required: false
   artifact-name:
     description: "The name of the distribution artifact to download"
     required: false
@@ -78,8 +84,8 @@ runs:
     - name: Cache SAM dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-sam-${{ inputs.cache-key }}-${{ github.head_ref || github.ref_name }}
-        restore-keys: ${{ runner.os }}-sam-${{ inputs.cache-key }}-
+        key: ${{ inputs.cache-key || format('{0}-{1}-{2}-{3}', runner.os, 'sam', inputs.cache-name, hashFiles(inputs.template || '**/template.y*ml')) }}
+        restore-keys: ${{ inputs.cache-restore-keys || format('{0}-{1}-{2}-', runner.os, 'sam', inputs.cache-name) }}
         path: .aws-sam
 
     - name: Get distribution artifact

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -90,7 +90,7 @@ runs:
 
     - name: Get distribution artifact
       if: ${{ inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -79,7 +79,7 @@ runs:
   steps:
     - name: Pull repository
       if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Cache SAM dependencies
       uses: actions/cache@v3

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -82,7 +82,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Cache SAM dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ inputs.cache-key || format('{0}-{1}-{2}-{3}', runner.os, 'sam', inputs.cache-name, hashFiles(inputs.template || '**/template.y*ml')) }}
         restore-keys: ${{ inputs.cache-restore-keys || format('{0}-{1}-{2}-', runner.os, 'sam', inputs.cache-name) }}

--- a/secure-pipelines/deploy-application/action.yml
+++ b/secure-pipelines/deploy-application/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Pull repository
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get distribution artifact
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}

--- a/secure-pipelines/deploy-application/action.yml
+++ b/secure-pipelines/deploy-application/action.yml
@@ -69,7 +69,7 @@ runs:
 
     - name: Get distribution artifact
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
 

--- a/secure-pipelines/deploy-fargate/action.yml
+++ b/secure-pipelines/deploy-fargate/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Get distribution artifact
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}

--- a/secure-pipelines/deploy-fargate/action.yml
+++ b/secure-pipelines/deploy-fargate/action.yml
@@ -59,7 +59,7 @@ runs:
   steps:
     - name: Pull repository
       if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get distribution artifact
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Get distribution artifact
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
 

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Pull repository
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Validate SAM template
       if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}


### PR DESCRIPTION
Cache SAM dependencies based on the template file, as the cache should be refreshed if the template file has changed.

Allow to specify a source code directory so the cache can be refreshed when the sources change.

Return the cache keys generated in the SAM build action so they can be passed to the deploy action.

---

- Use the latest versions of GitHub actions
- Include workspace root when installing npm dependencies