### PR TITLE
BAU: Update tests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,7 +1,7 @@
 name: Check PR
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-checkov:

--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -3,6 +3,10 @@ name: Beautify branch name test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-beautify-branch-name-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -1,7 +1,7 @@
 name: Beautify branch name test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Check length limit not validated
         if: ${{ steps.validate-length-limit.outcome != 'failure' }}
         run: |
-          echo "Invalid length limit has not been rejected"
+          echo "::error::Invalid length limit has not been rejected"
           exit 1
 
 

--- a/.github/workflows/test-check-stacks-exist.yml
+++ b/.github/workflows/test-check-stacks-exist.yml
@@ -3,6 +3,10 @@ name: Check stacks exist test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-check-stacks-exist-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-check-stacks-exist.yml
+++ b/.github/workflows/test-check-stacks-exist.yml
@@ -1,7 +1,7 @@
 name: Check stacks exist test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-delete-stacks.yml
+++ b/.github/workflows/test-delete-stacks.yml
@@ -1,7 +1,7 @@
 name: Delete stacks test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-delete-stacks.yml
+++ b/.github/workflows/test-delete-stacks.yml
@@ -3,6 +3,10 @@ name: Delete stacks test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-delete-stacks-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-deploy-to-paas.yml
+++ b/.github/workflows/test-deploy-to-paas.yml
@@ -3,6 +3,10 @@ name: Deploy to PaaS test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-deploy-to-paas-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-deploy-to-paas.yml
+++ b/.github/workflows/test-deploy-to-paas.yml
@@ -1,7 +1,7 @@
 name: Deploy to PaaS test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-get-ssm-parameters.yml
+++ b/.github/workflows/test-get-ssm-parameters.yml
@@ -3,6 +3,10 @@ name: Get SSM parameters test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-get-ssm-parameters-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-get-ssm-parameters.yml
+++ b/.github/workflows/test-get-ssm-parameters.yml
@@ -1,7 +1,7 @@
 name: Get SSM parameters test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-get-stale-stacks.yml
+++ b/.github/workflows/test-get-stale-stacks.yml
@@ -3,6 +3,10 @@ name: Get stale stacks test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-get-stale-stacks-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-get-stale-stacks.yml
+++ b/.github/workflows/test-get-stale-stacks.yml
@@ -1,7 +1,7 @@
 name: Get stale stacks test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-parse-parameters.yml
+++ b/.github/workflows/test-parse-parameters.yml
@@ -3,6 +3,10 @@ name: Parse parameters test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-parse-parameters-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-parse-parameters.yml
+++ b/.github/workflows/test-parse-parameters.yml
@@ -1,7 +1,7 @@
 name: Parse parameters test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-print-file-to-step-summary.yml
+++ b/.github/workflows/test-print-file-to-step-summary.yml
@@ -1,7 +1,7 @@
 name: Print file to step summary test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-print-file-to-step-summary.yml
+++ b/.github/workflows/test-print-file-to-step-summary.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check error returned on missing report
         if: ${{ steps.fail-on-missing-report.outcome != 'failure' }}
         run: |
-          echo "Error status not returned on missing report"
+          echo "::error::Error status not returned on missing report"
           exit 1
 
 
@@ -78,12 +78,10 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Stub result
           Stub result
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Include title
@@ -97,12 +95,10 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-with-title.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           **Report title**
           Stub result
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use code block
@@ -116,13 +112,11 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-code-block.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           ```
           Stub result
           ```
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use syntax highlighting
@@ -136,13 +130,11 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-syntax-highlight.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           ```shell
           Stub result
           ```
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use all elements
@@ -157,14 +149,12 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-all-elements.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           **Report title**
           ```shell
           Stub result
           ```
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Read from standard input
@@ -179,5 +169,5 @@ jobs:
           Standard input
           ```
           EOF
-          
-          echo "Standard input" | $REPORT | diff expected_file -
+
+          $REPORT <<< "Standard input" | diff expected_file -

--- a/.github/workflows/test-print-file-to-step-summary.yml
+++ b/.github/workflows/test-print-file-to-step-summary.yml
@@ -3,6 +3,10 @@ name: Print file to step summary test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-print-file-to-step-summary-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-print-list-to-step-summary.yml
+++ b/.github/workflows/test-print-list-to-step-summary.yml
@@ -31,11 +31,9 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values: one
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Accumulate results
@@ -50,12 +48,10 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values: one
           Reported other values: two
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use single value message
@@ -71,11 +67,9 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-single-value.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported single value: one-and-only
           EOF
-          
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Replace token in single value message
@@ -91,11 +85,9 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-single-value-token.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported one-and-only value
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use code block for single value
@@ -110,11 +102,9 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-code-block-single.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values: `single`
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Print multiple values with extra spaces
@@ -129,7 +119,7 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-multiple-values.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values:
             - one
             - two
@@ -137,8 +127,6 @@ jobs:
             - four
             - five
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use code block for multiple values
@@ -153,14 +141,12 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-code-block-multiple.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values:
             - `one`
             - `two`
             - `three`
           EOF
-
-          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
 
 
       - name: Print multi-line values
@@ -178,14 +164,12 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-multiline-values.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values:
             - one
             - two
             - three
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Print multi-line values with spaces and empty lines
@@ -211,15 +195,13 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-multiline-values-spaces.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values:
             - one two   three
             - blue pink yellow
             - apple banana orange
             - seafood pasta sushi
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Use code block for multi-line values with spaces
@@ -238,14 +220,12 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-multiline-values-block.txt
         run: |
-          cat << 'EOF' > expected_file
+          diff "$OUTPUT_FILE" - << 'EOF'
           Reported values:
             - `one two three`
             - `blue pink yellow`
             - `apple banana orange`
           EOF
-
-          diff "$OUTPUT_FILE" expected_file
 
 
       - name: Complete without an error when given an empty list
@@ -261,7 +241,7 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-empty-list.txt
         run: |
-          [[ -s $OUTPUT_FILE ]] && echo "Expected the output file to be empty" && exit 1 || exit 0
+          [[ -s $OUTPUT_FILE ]] && echo "::error::Expected the output file to be empty" && exit 1 || exit 0
 
 
       - name: Complete without an error when given an empty multi-line value
@@ -285,4 +265,4 @@ jobs:
         env:
           OUTPUT_FILE: ${{ runner.temp }}/report-empty-list-multiline.txt
         run: |
-          [[ -s $OUTPUT_FILE ]] && echo "Expected the output file to be empty" && exit 1 || exit 0
+          [[ -s $OUTPUT_FILE ]] && echo "::error::Expected the output file to be empty" && exit 1 || exit 0

--- a/.github/workflows/test-print-list-to-step-summary.yml
+++ b/.github/workflows/test-print-list-to-step-summary.yml
@@ -3,6 +3,10 @@ name: Print list to step summary test
 on: pull_request
 permissions: {}
 
+concurrency:
+  group: test-print-list-to-step-summary-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Test action

--- a/.github/workflows/test-print-list-to-step-summary.yml
+++ b/.github/workflows/test-print-list-to-step-summary.yml
@@ -1,7 +1,7 @@
 name: Print list to step summary test
 
 on: pull_request
-permissions: read-all
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/test-upload-assets.yml
+++ b/.github/workflows/test-upload-assets.yml
@@ -49,13 +49,13 @@ jobs:
             echo "::error::Expected the ZIP file to have been uploaded to the correct S3 location" && exit 1
 
           unzip some-stack.zip -d uploaded-zip
-          cd uploaded-zip || exit
+          cd uploaded-zip || exit 1
 
           diff ZipSignature - <<< "$KMS_SIGNATURE"
           diff govuk_fe_version.txt - < <(jq --raw-output .version "$WORKDIR"/node_modules/govuk-frontend/package.json)
 
           unzip public.zip -d assets
-          cd assets || exit
+          cd assets || exit 1
 
           ! [[ -f public/javascripts/application.js ]] &&
             echo "::error::Expected assets to have been uploaded" && exit 1 || exit 0


### PR DESCRIPTION
- Restrict permissions for test workflows
- Print errors to the action summary
- Use heredocs for file comparisons with diff for more compact syntax
- Explicitly exit with an error status code if `cd` fails
- Add concurrency to tests
  Stop running tests if an update is pushed to a PR.