### PR TITLE
BAU: Allow to specify a custom delimiter in the parse parameters action

### DIFF
--- a/.github/workflows/test-parse-parameters.yml
+++ b/.github/workflows/test-parse-parameters.yml
@@ -98,6 +98,19 @@ jobs:
           [[ "${{ steps.parse-single-line-params-kvps.outputs.parsed-parameters }}" == "sky='blue' test='foo bar'" ]]
 
 
+      - name: Parse single-line parameters with a custom delimiter
+        id: parse-single-line-params-delim
+        uses: ./parse-parameters
+        with:
+          delimiter: "&"
+          parameters: sky=blue & test="foo bar"&food=mango
+          associative-array: false
+
+      - name: Check single-line parameters parsed into key-value pairs
+        run: |
+          [[ "${{ steps.parse-single-line-params-delim.outputs.parsed-parameters }}" == "sky='blue' test='foo bar' food='mango'" ]]
+
+
       - name: Parse multi-line parameters
         id: parse-multi-line-params
         uses: ./parse-parameters

--- a/parse-parameters/action.yml
+++ b/parse-parameters/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Encode parsed parameters in the format key=<key>,value='<value>' (if not using an associative array)"
     required: false
     default: "false"
+  delimiter:
+    description: "The delimiter used to separate key=value pairs on a single line"
+    required: false
+    default: |
 outputs:
   parsed-parameters:
     description: "A string representation of a regular or an associative array containing the parsed params"
@@ -26,6 +30,7 @@ runs:
       id: parse-parameters
       shell: bash
       env:
+        DELIMITER: ${{ inputs.delimiter }}
         PARAMETERS: ${{ inputs.parameters }}
         LONG_FORMAT: ${{ inputs.long-format == 'true' }}
         ASSOCIATIVE_ARRAY: ${{ inputs.associative-array == 'true' }}

--- a/scripts/parse-parameters.sh
+++ b/scripts/parse-parameters.sh
@@ -3,6 +3,7 @@ set -eu
 : "${PARAMETERS}"               # The parameters to parse
 : "${ASSOCIATIVE_ARRAY:=false}" # Whether to encode output as a string representing an associative array
 : "${LONG_FORMAT:=false}"       # Whether to encode the parameters in the form of "key=key,value='value'" strings
+: "${DELIMITER:=|}"             # The delimiter used to separate key=value pairs on a single line
 
 [[ $PARAMETERS ]] || exit 0
 
@@ -12,7 +13,7 @@ long=${LONG_FORMAT}
 
 num_lines=$(wc -l <<< "$raw_parameters")
 if [[ $num_lines -le 1 ]]; then
-  IFS="|" read -ra key_value_pairs <<< "$raw_parameters"
+  IFS="$DELIMITER" read -ra key_value_pairs <<< "$raw_parameters"
 else
   mapfile -t key_value_pairs <<< "$raw_parameters"
 fi


### PR DESCRIPTION
Allow to override the default delimiter