### PR TITLE
Execution Id: Not always able to retrieve the id, timeout issue.

### DIFF
--- a/secure-pipelines/deploy-fargate/action.yml
+++ b/secure-pipelines/deploy-fargate/action.yml
@@ -187,6 +187,7 @@ runs:
 
     - name: Start pipeline execution
       if: ${{ steps.check-artifact-exists.outputs.artifact-version != null }}
+      id: start-execution
       shell: bash
       env:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}


### PR DESCRIPTION
Sometimes the builds timeout waiting for a secure pipeline deployment that has actually been successful, because it's not able to identify the execution id of the pipeline. E.g. https://github.com/govuk-one-login/onboarding-self-service-experience/actions/runs/9419515532/job/26019834148