### PR TITLE
changing CODEOWNERS to teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CharlesIC @TobySaundersGDS
+* @cri-common-admins @devplatform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cri-common-admins @devplatform
+* @govuk-one-login/cri-common-admins @govuk-one-login/devplatform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/cri-common-admins @govuk-one-login/devplatform
+* @govuk-one-login/cri-common-admins @govuk-one-login/dev-platform


### PR DESCRIPTION
The changes the permitted PR reviewers to the teams defined in the configuration repo instead of two individuals. 