### PR TITLE
OJ-2824: Empty stack buckets before deleting stacks

### DIFF
--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: "Delete a stack only if it is in one of the failed states"
     required: false
     default: "false"
+  empty-buckets:
+    description: "Empty stack buckets before deletion. This will result in long runtimes for large buckets."
+    default: "false"
   verbose:
     description: "Print all output messages"
     required: false
@@ -36,4 +39,5 @@ runs:
       env:
         STACK_NAMES: ${{ inputs.stack-names }}
         ONLY_FAILED: ${{ inputs.only-if-failed == 'true' }}
+        EMPTY_BUCKETS: ${{ inputs.empty-buckets == 'true' }}
         VERBOSE: ${{ inputs.verbose == 'true' }}

--- a/sam/get-stale-stacks/action.yml
+++ b/sam/get-stale-stacks/action.yml
@@ -1,6 +1,13 @@
 name: "Get stale stacks"
 description: "Retrieve names of AWS SAM stacks older than a set threshold, and filtered by name and tags"
 inputs:
+  aws-role-arn:
+    description: "AWS role ARN to assume when validating the template"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
   threshold-days:
     description: "Get stacks older than the specified number of days"
     required: false
@@ -21,9 +28,19 @@ outputs:
   stack-names:
     description: "Filtered stack names"
     value: ${{ steps.filter-stacks.outputs.stack-names }}
+  stack-names-json:
+    description: "Filtered stack names formatted as a JSON array"
+    value: ${{ steps.filter-stacks.outputs.stack-names-json }}
 runs:
   using: composite
   steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ inputs.aws-region }}
+
     - name: Parse tag filters
       id: parse-tag-filters
       shell: bash

--- a/sam/get-stale-stacks/filter-stacks.sh
+++ b/sam/get-stale-stacks/filter-stacks.sh
@@ -39,4 +39,8 @@ for stack in "${stack_names[@]}"; do
   echo "$stack | last updated: $last_updated_date"
 done
 
+[[ ${stale_stacks[*]} && ${#stale_stacks[@]} -gt 0 ]] &&
+  stale_stacks_json=$(jq --raw-input < <(IFS=$'\n' && echo "${stale_stacks[*]}") | jq --slurp --compact-output)
+
 echo "stack-names=${stale_stacks[*]}" >> "$GITHUB_OUTPUT"
+echo "stack-names-json=${stale_stacks_json:-[]}" >> "$GITHUB_OUTPUT"

--- a/scripts/aws/cloudformation/list-stack-buckets.sh
+++ b/scripts/aws/cloudformation/list-stack-buckets.sh
@@ -5,7 +5,7 @@ base_dir="$(dirname "${BASH_SOURCE[0]}")"
 report="$base_dir"/../../report-step-result/print-list.sh
 
 : "${STACK_NAME}"          # Name of the stack containing the buckets to list
-: "${VERBOSE:=true}"       # Whether to print to step summary
+: "${VERBOSE:=false}"      # Whether to print to step summary
 : "${ERROR_STATUS:=false}" # Whether to exit with an error status if no buckets have been found
 
 buckets=$(aws cloudformation list-stack-resources \
@@ -18,7 +18,7 @@ if ! [[ $buckets ]]; then
   $ERROR_STATUS && exit 1 || exit 0
 fi
 
-$VERBOSE && VALUES="$buckets" MESSAGE="Found buckets in stack \`$STACK_NAME\`" \
-  SINGLE_MESSAGE="Found a bucket in stack \`$STACK_NAME\`" $report >> "$GITHUB_STEP_SUMMARY"
+$VERBOSE && VALUES="$buckets" MESSAGE="🪣 Found buckets in stack \`$STACK_NAME\`" \
+  SINGLE_MESSAGE="🪣 Found a bucket in stack \`$STACK_NAME\`" $report >> "$GITHUB_STEP_SUMMARY"
 
 echo "$buckets"

--- a/scripts/aws/s3/empty-bucket.sh
+++ b/scripts/aws/s3/empty-bucket.sh
@@ -1,11 +1,59 @@
-# Deletes all current objects from a bucket
+# Deletes all objects and object versions from a bucket
 set -eu
 
-: "${BUCKET}"        # Name of the bucket to empty
-: "${VERBOSE:=true}" # Whether to print to step summary
-
-echo "Deleting objects from bucket $BUCKET"
-aws s3 rm "s3://$BUCKET" --recursive --quiet
+: "${BUCKET}"         # Name of the bucket to empty
+: "${STEP:=1000}"     # Step size when removing object versions
+: "${VERBOSE:=false}" # Whether to print to step summary
 
 $VERBOSE && step_summary=$GITHUB_STEP_SUMMARY
-echo "Emptied bucket \`$BUCKET\`" | tee -a "${step_summary[@]}"
+
+function get-versioning {
+  aws s3api get-bucket-versioning --bucket "$BUCKET" --output text
+}
+
+function get-object-versions {
+  aws s3api list-object-versions --bucket "$BUCKET" --query \
+    "{Versions: Versions[].{Key:Key,VersionId:VersionId}, DeleteMarkers: DeleteMarkers[].{Key:Key,VersionId:VersionId}}"
+}
+
+function delete-objects {
+  local type=$1 objects count
+  objects=$(jq --compact-output ".$type" <<< "$versions")
+  count=$(jq length <<< "$objects")
+
+  [[ $count -eq 0 ]] && echo "  No $type found" && return 0
+  echo "  Deleting $count $type... "
+
+  local batch lower=0 upper=0
+  while [[ $upper -lt $count ]]; do
+    upper=$((upper + STEP))
+    [[ $upper -gt $count ]] && upper=$count
+    batch=$(jq --compact-output "{Objects: .[$lower:$upper], Quiet: true}" <<< "$objects")
+    aws s3api delete-objects --bucket "$BUCKET" --delete file:///dev/stdin <<< "$batch"
+    lower=$upper
+  done
+}
+
+function delete-versions {
+  delete-objects Versions && delete-objects DeleteMarkers
+}
+
+echo "Emptying bucket $BUCKET"
+
+echo "  Deleting objects..."
+aws s3 rm "s3://$BUCKET" --recursive --quiet
+
+echo -n "  Checking versioning configuration... "
+[[ $(get-versioning) == Enabled ]] && versioning=true && echo "[Enabled]" || echo "[Disabled]"
+
+if ${versioning:-false}; then
+  echo "  Getting object versions..."
+  versions=$(get-object-versions)
+
+  if ! delete-versions; then
+    echo "❌ Failed to empty bucket \`$BUCKET\`" | tee -a "${step_summary[@]}"
+    exit 1
+  fi
+fi
+
+echo "🗑️ Emptied bucket \`$BUCKET\`" | tee -a "${step_summary[@]}"


### PR DESCRIPTION
**OJ-2824: Delete object versions from a bucket**
Update the `empty-bucket.sh` script to list and delete all object versions and deletion markers from a bucket to empty it and allow CloudFormation to delete it.

**OJ-2824: Empty all buckets before deleting a SAM stack**
CloudFormation will fail to delete a stack with buckets that are not empty.
Use the S3 scripts in the `sam/delete-stacks` action to list and empty all buckets managed by a stack prior to its deletion.

**OJ-2824: Return stale stacks as a JSON array**
This allows using the output of the `sam/get-stale-stacks` action as a matrix input in the deletion action and delete the stacks in parallel.

Also add an optional step to assume an AWS role to the `sam/get-stale-stacks` action.


<img width="750" alt="Screenshot 2024-10-29 at 13 12 58" src="https://github.com/user-attachments/assets/38bab224-57b9-4b42-9540-9b9d0a7abddb">

<img width="981" alt="Screenshot 2024-10-29 at 13 58 28" src="https://github.com/user-attachments/assets/940361c8-6d27-4655-a5f5-d3299c28f6b6">