### PR TITLE
OJ-2950: Add optional node-version input to pre-commit action

### DIFF
--- a/code-quality/run-pre-commit/action.yml
+++ b/code-quality/run-pre-commit/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: "Install dev packages from package.json - this is needed for hooks which have dependencies"
     required: false
     default: "false"
+  node-version:
+    description: "Node version to set up. The system version is used if not specified."
+    required: false
   package-manager:
     description: "The package manager to use to install dependencies - npm or yarn"
     required: false
@@ -55,6 +58,7 @@ runs:
       if: ${{ inputs.install-dependencies == 'true' }}
       uses: actions/setup-node@v4
       with:
+        node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}
 
     - name: Install dependencies


### PR DESCRIPTION
## Description

### What changed
Add optional node-version input to pre-commit action

### Why did it change
To allow a consumer to specify a node version for this action, as is possible with other actions such as `install-dependencies`

### Screenshots

With input
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/16cba81f-2a6b-43ff-9d95-08a028c1e224" />

Without input
<img width="1707" alt="image" src="https://github.com/user-attachments/assets/de8767fd-83c3-4fcf-918b-bf55d40ce575" />
