### PR TITLE
update: Sonar is deprecating a gh action

### DIFF
--- a/code-quality/sonarcloud/action.yml
+++ b/code-quality/sonarcloud/action.yml
@@ -57,7 +57,7 @@ runs:
         github-token: ${{ (steps.coverage.outputs.run-id || github.run_id) != github.run_id && inputs.github-token || null }}
 
     - name: Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v4.2.1
       with:
         args: ${{ inputs.args }}
         projectBaseDir: ${{ inputs.projectBaseDir }}


### PR DESCRIPTION
This updates to the more recent github action
the inputs are the same when using cloud
https://github.com/SonarSource/sonarqube-scan-action?tab=readme-ov-file#cloud-1

