### PR TITLE
BAU: Enable dependabot on all actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories: ["**/*"]
     schedule:
       interval: weekly
     target-branch: main


### PR DESCRIPTION
By default, dependabot only updates actions in the `.github` and root directories. Use a recursive wildcard search to attempt to make dependabot update actions in other directories as well.