### PR TITLE
SPT-1521: Do not error if get-stale-stacks finds no matching stacks

### DIFF
--- a/sam/get-stale-stacks/filter-stacks.sh
+++ b/sam/get-stale-stacks/filter-stacks.sh
@@ -16,7 +16,7 @@ echo "Cut off date: $cut_off_date"
 stacks=$(aws cloudformation describe-stacks | jq '.Stacks[]')
 
 stack_names=$(jq -r '.StackName' <<< "$stacks")
-[[ $name_filter ]] && stack_names=$(grep "$name_filter" <<< "$stack_names")
+[[ $name_filter ]] && stack_names=$(grep "$name_filter" <<< "$stack_names" || true)
 mapfile -t stack_names <<< "$stack_names"
 
 tag_names=("${!tag_filters[@]}")


### PR DESCRIPTION
Update the call to `grep` for matching `$name_filter` so that the command succeeds even if there are no matches, the rest of the script copes correctly if there is nothing to do.

Teams using this action are seeing jobs failing, when there is nothing to clean up, as `grep` exits with a non-zero exit code if no matches are found.

This could be addressed by adding `continue_on_error` to the tasks in the calling workflows, but it would be neater to fix up the action so it doesn't exit with an error code.

Example failing workflow run without fix:
https://github.com/govuk-one-login/ipv-contra-indicators/actions/runs/15704115972

Example workflow run with this fix:
https://github.com/govuk-one-login/ipv-contra-indicators/actions/runs/15728316208

Spot checking other team's repos that use this actions, I can see failing workflows in, at least, these following repos:
[ipv-cri-kbv-hmrc-api](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-api/tree/4ce59c8d28ec98aa1458e737db7d6430eb23b3ae)
[fraud-frontend](https://github.com/govuk-one-login/fraud-frontend)
[ipv-cri-otg-hmrc](https://github.com/govuk-one-login/ipv-cri-otg-hmrc)