### PR TITLE
Update node/run-script to pass working dir to setup-node

### DIFF
--- a/node/run-script/action.yml
+++ b/node/run-script/action.yml
@@ -27,12 +27,13 @@ runs:
       uses: actions/checkout@v6
 
     - name: Set up Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         registry-url: ${{ inputs.registry-url }}
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ inputs.package-manager }}
+        cache-dependency-path: ${{ inputs.working-directory }}
 
     - name: Install dependencies
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
This PR implements similar changes to those in #204, but for the run-script action. It will resolve issues like these, which occur when using run-script in a repo without a root package.json file: https://github.com/govuk-one-login/ipv-cri-common-infrastructure/actions/runs/25381089797/job/74429312842

```
/opt/hostedtoolcache/node/20.18.3/x64/bin/npm config get cache
/home/runner/.npm
Error: Dependencies lock file is not found in /home/runner/work/repo-name/repo-name. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```