### PR TITLE
FPAD-7890: Added check to ensure a bucket exists before attempting deletion

### DIFF
--- a/scripts/aws/s3/empty-bucket.sh
+++ b/scripts/aws/s3/empty-bucket.sh
@@ -38,6 +38,13 @@ function delete-versions {
   delete-objects Versions && delete-objects DeleteMarkers
 }
 
+if ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  msg="⚠️ Bucket \`$BUCKET\` does not exist, skipping"
+  echo "$msg"
+  $VERBOSE && echo "$msg" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
 echo "Emptying bucket $BUCKET"
 
 echo "  Deleting objects..."

--- a/scripts/aws/s3/empty-bucket.sh
+++ b/scripts/aws/s3/empty-bucket.sh
@@ -38,7 +38,7 @@ function delete-versions {
   delete-objects Versions && delete-objects DeleteMarkers
 }
 
-if ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+if ! aws s3api head-bucket --bucket "$BUCKET" 2> /dev/null; then
   msg="⚠️ Bucket \`$BUCKET\` does not exist, skipping"
   echo "$msg"
   $VERBOSE && echo "$msg" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
We've been seeing issues with bucket deletion failing as a part of deleting stale stacks. The root cause of this is stacks containing buckets that no longer exist, the empty bucket script attempts to run and cannot find the bucket which errors out. These changes add in a check for whether the bucket exists before attempting to empty it.

Example of this script failing: https://github.com/govuk-one-login/fraud-ticf-cri/actions/runs/28948250004/job/85887711704