### PR TITLE
BAU: [send-workflow-slack-notifications] Add AWS role configuration

### DIFF
--- a/slack/send-workflow-slack-notification/README.md
+++ b/slack/send-workflow-slack-notification/README.md
@@ -18,6 +18,8 @@ A SNS Topic arn is the only information required to be able to post a message to
 - `message-description`: The description or body of the message to send. If omitted, this defaults to the name of the workflow and a link to the workflow run
 - `status`: Optional status to include in the default message description (e.g., 'Succeeded', 'Failed'). If included, it is inserted into the message description, so the message becomes the name of the workflow, the status and a link to the workflow run. This only applies to the default message. If a custom message is provided in `message-description` the `status` is ignored, though status information can be included in that custom message
 - `status-icon`: Optional icon to include with the status in the default message title (e.g., '✅'). If included, it is prepended to the message title, so the title becomes the icon and the name of the workflow. If status icon is not provided, but a status of 'failed' (case insensitive) is provided, the status icon defaults to ❌. If status icon is not provided, but a status of 'succeeded' (case insensitive) is provided, the status icon defaults to ✅
+- `aws-role-arn`: Optional. The ARN for IAM role for GitHub to assume. Role must have enough permissions to publish to `sns-topic-arn`
+- `aws-region`: Optional. The AWS region to be used when authenticating with `aws-role-arn`. Defaults to `eu-west-2`
 
 ## Using actions from this repo in other repos
 

--- a/slack/send-workflow-slack-notification/action.yml
+++ b/slack/send-workflow-slack-notification/action.yml
@@ -1,6 +1,13 @@
 name: "Send a Workflow Slack Notification"
 description: "Sends a notification to a Slack channel"
 inputs:
+  aws-role-arn:
+    description: "ARN of AWS role to assume when sending SNS messages"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
   sns-topic-arn:
     description: "SNS Topic ARN to publish the notification to"
     required: true
@@ -19,6 +26,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ inputs.aws-region }}
+
     - name: Slack notification
       id: slack-notification
       shell: bash


### PR DESCRIPTION
- Configuration is optional, workflows require authentication with AWS to publish to an SNS topic

Tested in devplatform-deploy workflow:
<img width="1047" height="350" alt="Screenshot 2026-08-03 at 16 02 55" src="https://github.com/user-attachments/assets/d0a67c11-4324-49e5-bb36-91778e2c8bac" />
